### PR TITLE
Proposal: coordinates lib is also a function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/test/test.js
+++ b/test/test.js
@@ -50,13 +50,15 @@ var strings = {
 
 test('Testing extraction of coordinates from a bunch of different strings', function(t) {
 
-    t.plan(Object.keys(strings).length*2)
+    t.plan(Object.keys(strings).length*3);
 
     Object.keys(strings).forEach(function(str){
         var extract = coords.extract(str);
-        t.deepEqual(extract, strings[str].extract, 'Extracting coords from '+str)
+        t.deepEqual(extract, strings[str].extract, 'Extracting coords from '+str);
 
         var pair = coords.pair(extract);
         t.deepEqual(pair, strings[str].pair, 'Extracting coord pair from '+JSON.stringify(extract));
-    })
+
+        t.deepEqual(coords(str), strings[str].pair, 'Extracting coord pair from '+str);
+    });
 });


### PR DESCRIPTION
**Proposal:**
This is a change that will simplify use.
The coordinate object is also a function. And can be called.

Instead of using:

``` javascript
coords.pair(coords.extract(str));
```

You can use:

``` javascript
coords(str);
```

You can still use coords.pair and coords.extract if needed.
