### PR TITLE
Fixed bug with lat/long valued 0, added test case

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,8 +88,8 @@ function normalize (dd_struct) {
   d[1] = d[1].replace(remove,'')
 
   // Remove leading zeroes
-  if(d[0][0] == '0') d[0] = d[0].slice(1)
-  if(d[1][0] == '0') d[1] = d[1].slice(1)
+  if(d[0].length > 1 && d[0][0] == '0') d[0] = d[0].slice(1)
+  if(d[1].length > 1 && d[1][0] == '0') d[1] = d[1].slice(1)
 
   // Add prefixes
   d[0] = lat_prefix + d[0]

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,11 @@ var strings = {
       'pair': "7;30;DD",
       'normalize': "7;30"
     },
+    "7 0": {
+      'extract': "7 0;DD",
+      'pair': "7;0;DD",
+      'normalize': "7;0"
+    },
 
     /***
         DDM testing
@@ -123,20 +128,14 @@ var strings = {
 
 test('Testing extraction of coordinates from a bunch of different strings', function(t) {
 
-    t.plan(Object.keys(strings).length);
+    t.plan(Object.keys(strings).length * 3);
 
     Object.keys(strings).forEach(function(str){
         var extract = coords.extract(str)
         t.deepEqual(extract, strings[str].extract, 'Extracting coords from '+str)
-/*
         var pair = coords.pair(extract);
         t.deepEqual(pair, strings[str].pair, 'Extracting coord pair from '+JSON.stringify(extract))
-
         var normalize = coords.normalize(pair.split(';').slice(0,2).join(';'))
         t.deepEqual(normalize, strings[str].normalize, "Normalizing pair from "+pair)
-
-        t.deepEqual(coords(str), strings[str].pair, 'Extracting coord pair from '+str)
-*/
-
     });
 });


### PR DESCRIPTION
"27 0" ended up being "27;" after normalize because of removal of leading zeroes.
Now fixed!
